### PR TITLE
Add ignoreRTL prop

### DIFF
--- a/src/tree/Element.d.mts
+++ b/src/tree/Element.d.mts
@@ -890,6 +890,14 @@ declare namespace Element {
     flexItem: Element.FlexItem | false;
 
     /**
+     * ignoreRTL
+     * 
+     * @remarks
+     * Ignore apply RTL direction if `window.isRTL=true`. Effected to nested children if they are not setted
+     */
+    ignoreRTL: boolean;
+
+    /**
      * Starts a smooth transition for all the included properties of the object
      *
      * @remarks
@@ -1727,6 +1735,9 @@ declare class Element<
   rttLazy: boolean;
 
   renderOffscreen: boolean;
+
+  get ignoreRTL(): boolean;
+  set ignoreRTL(v: boolean);
 
   colorizeResultTexture: boolean;
 

--- a/src/tree/Element.mjs
+++ b/src/tree/Element.mjs
@@ -2054,6 +2054,14 @@ export default class Element {
         this.__core.flexItem = v;
     }
 
+    get ignoreRTL() {
+        return this.__core.ignoreRTL;
+    }
+
+    set ignoreRTL(v) {
+        this.__core.ignoreRTL = v;
+    }
+
     static isColorProperty(property) {
         return property.toLowerCase().indexOf("color") >= 0;
     }

--- a/src/tree/core/ElementCore.d.mts
+++ b/src/tree/core/ElementCore.d.mts
@@ -117,6 +117,8 @@ declare class ElementCore {
   set visible(v: boolean);
   get zIndex(): number;
   set zIndex(v: number);
+  get ignoreRTL(): boolean;
+  set ignoreRTL(v: boolean);
 
   /**
    * Fill the array `children` with all the ElementCore instances (including itself and

--- a/src/tree/core/ElementCore.mjs
+++ b/src/tree/core/ElementCore.mjs
@@ -662,7 +662,7 @@ export default class ElementCore {
     };
 
     _setIgnoreRTL(parent) {
-        if (parent.ignoreRTL && parent._children) {
+        if (parent && parent.ignoreRTL && parent._children) {
             for (let i = 0, n = parent._children.length; i < n; i++) {
                 let c = parent._children[i];
                 if (c && c.ignoreRTL != false) {

--- a/src/tree/core/ElementCore.mjs
+++ b/src/tree/core/ElementCore.mjs
@@ -723,10 +723,6 @@ export default class ElementCore {
             removed[i].setParent(null);
         }
         for (let i = 0, n = added.length; i < n; i++) {
-            //inherit ignoreRTL from parent if child is not setted
-            if (this._ignoreRTL && added[i].ignoreRTL != false) {
-                added[i].ignoreRTL = this._ignoreRTL;
-            }
             added[i].setParent(this);
         }
     }


### PR DESCRIPTION
# What did I do?
- Added `ignoreRTL`. Components always display LTR direction
- Nested components are inherited value from parent if prop is not setted

## Nested component inherits from parent
![nested_component_against_effected](https://github.com/9afar/Lightning/assets/47239428/99e5f9b4-4857-4300-86ba-b24309ec3a56)
## Nested component doesn't inherit from parent
![nested_component_effected](https://github.com/9afar/Lightning/assets/47239428/7d357d9d-1197-4b2c-8605-55d5dbbaaaaa)
