### PR TITLE
Fix: add ignoreRTL for text-texture

### DIFF
--- a/dist/src/textures/TextTexture.mjs
+++ b/dist/src/textures/TextTexture.mjs
@@ -84,7 +84,7 @@ export default class TextTexture extends Texture {
     get fontBaselineRatio() {
         return this._fontBaselineRatio;
     }
-    
+
     set fontBaselineRatio(v) {
         if (this._fontBaselineRatio !== v) {
             this._fontBaselineRatio = v;
@@ -492,6 +492,15 @@ export default class TextTexture extends Texture {
         }
     }
 
+    get ignoreRTL() {
+        return this._ignoreRTL;
+    }
+
+    set ignoreRTL(v) {
+        this._ignoreRTL = v;
+        this._changed();
+    }
+
     _getIsValid() {
         return !!this.text;
     }
@@ -689,6 +698,7 @@ export default class TextTexture extends Texture {
         obj.cutSy = this._cutSy;
         obj.cutEy = this._cutEy;
         obj.advancedRenderer = this._advancedRenderer;
+        obj.ignoreRTL = this._ignoreRTL;
         return obj;
     }
 
@@ -738,6 +748,7 @@ proto._cutSy = 0;
 proto._cutEy = 0;
 proto._advancedRenderer = false;
 proto._fontBaselineRatio = 0;
+proto._ignore = false;
 
 
 import TextTextureRenderer from "./TextTextureRenderer.mjs";

--- a/dist/src/textures/TextTextureRenderer.mjs
+++ b/dist/src/textures/TextTextureRenderer.mjs
@@ -272,7 +272,7 @@ export default class TextTextureRenderer {
 
         // Canvas context has been reset.
         this.setFontProperties();
-        if (window.isRTL) {
+        if (window.isRTL && !this._settings.ignoreRTL) {
             this._context.direction = 'rtl';
             this._context.textAlign = 'left';
         }

--- a/dist/src/tree/Element.mjs
+++ b/dist/src/tree/Element.mjs
@@ -1748,6 +1748,8 @@ export default class Element {
     enableTextTexture() {
         if (!this.texture || !(this.texture instanceof TextTexture)) {
             this.texture = new TextTexture(this.stage);
+            // Cannot find a better workaround.
+            // I want to retrieve the *ignoreRTL* from this.__core, but the child element always create ahead of parent.
             this.texture.ignoreRTL = this.ignoreRTL;
             if (!this.texture.w && !this.texture.h) {
                 // Inherit dimensions from element.

--- a/dist/src/tree/Element.mjs
+++ b/dist/src/tree/Element.mjs
@@ -1748,7 +1748,7 @@ export default class Element {
     enableTextTexture() {
         if (!this.texture || !(this.texture instanceof TextTexture)) {
             this.texture = new TextTexture(this.stage);
-
+            this.texture.ignoreRTL = this.ignoreRTL;
             if (!this.texture.w && !this.texture.h) {
                 // Inherit dimensions from element.
                 // This allows userland to set dimensions of the Element and then later specify the text.


### PR DESCRIPTION
Add the `ignoreRTL` for the text-texture renderer when we want to ignore the bidi-layout. This will be used for the key of keyboard when it's in `Arabic` language.